### PR TITLE
Delete unnecessary translated strings, replace Historik with Historie

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -724,10 +724,6 @@
     <string name="nsclienthaswritepermission">Nightscout-Client hat Schreibrechte</string>
     <string name="maxiobset">Maximales IOB richtig gesetzt</string>
     <string name="closedmodeenabled">Closed mode aktiviert</string>
-    <string name="virtualpump_lastconnection_label">Letzte Verbindung</string>
-    <string name="virtualpump_basebasalrate_label">Basis-Basalrate</string>
-    <string name="virtualpump_reservoir_label">Reservoir</string>
-    <string name="danar_lastbolus">Letzter Bolus:</string>
     <string name="objectives_7_objective">Aktiviere zusätzliche Funktionen wie z. B. den SMB</string>
     <string name="btwatchdog_title">BT Watchdog</string>
     <string name="DexcomG5">DexcomG5 App (patched)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -306,7 +306,7 @@
     <string name="simpleprofile_shortname">SP</string>
     <string name="profileviewer_shortname">PROF</string>
     <string name="overview_shortname">HOME</string>
-    <string name="objectives_shortname">OBJ</string>
+    <string name="objectives_shortname">ZIEL</string>
     <string name="oaps_shortname">OAPS</string>
     <string name="loop_shortname">LOOP</string>
     <string name="localprofile_shortname">LP</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -744,13 +744,13 @@
     <string name="combo_pump_action_cancelling_tbr">TBR wird abgebrochen</string>
     <string name="combo_pump_action_setting_tbr">TBR wird gesetzt (%d%% / %d min)</string>
     <string name="combo_pump_action_bolusing">Bolus (%.1f E) wird abgegeben</string>
-    <string name="combo_activity_reading_pump_history">Historik wird gelesen</string>
+    <string name="combo_activity_reading_pump_history">Historie wird gelesen</string>
     <string name="combo_activity_setting_basal_profile">Basalratenprofil wird aktualisiert</string>
     <string name="combo_error_bolus_recovery_progress">Verbindung wurde unterbrochen, es wird versucht fortzusetzen</string>
     <string name="combo_error_bolus_verification_failed">Der abgegebene Bolus konnte nicht bestätigt werden. Bitte prüfen Sie auf der Pumpe ob ein Bolus abgegeben wurde und erstellen Sie einen Eintrag im Careportal Reiter falls nötig.</string>
     <string name="combo_error_no_bolus_delivered">Die Bolusabgabe ist fehlgeschlagen, es wurde scheinbar kein Bolus abgegeben. Bitte prüfen Sie auf der Pumpe ob ein Bolus abgegeben wurde. Um dopplte Boli durch Programmfehler zu vermeiden werden Boli nicht automatisch erneut versucht.</string>
     <string name="combo_error_partial_bolus_delivered">Wegen eines Fehlers wurden nur %.2f IE von den angeforderten %.2f IE abgegeben. Bitte prüfen Sie den abgegeben Bolus auf der Pumpe.</string>
-    <string name="combo_history">Historik</string>
+    <string name="combo_history">Historie</string>
     <string name="combo_pump_action_refreshing">Status wird aktualisiert</string>
     <string name="combo_pump_action_initializing">Die Pumpe wird initialisiert</string>
     <string name="combo_pump_connected_now">Jetzt</string>
@@ -774,5 +774,5 @@
     <string name="combo_notification_check_time_date">Bitte aktualisieren Sie die Uhr auf der Pumpe</string>
     <string name="combo_no_tdd_data_note">Um die TDD-Statistik der Pumpe zu lesen, drücken Sie den TDDS Knopf lange.\nWARNUNG: Es gibt einen bekannten Fehler in der Pumpe der dazu führt, dass die Pumpe nach dieser Aktion erst wieder Verbindungen annimmt, wenn auf der Pumpe selbst ein Konpf gedrückt wird. Aus diesem Grund sollte diese Aktion nicht durchgeführt werden.</string>
     <string name="combo_read_full_history_confirmation">Sind Sie sich sicher, dass Sie diese Aktion ausführen möchen und verstehen Sie die Konsequenzen die sich daraus ergeben?</string>
-    <string name="combo_read_full_history_warning">Diese Aktion wird die gesamte Historik und die Basalrate aus der Pumpe auslesen. Boli und temporäre Basalrate werden zu den Behandlungen hinzugefügt wenn diese noch nicht vorhanden sind. Dies kann zu doppelten Einträge und somit zu falschen IOB-Werten führen, da die Uhr der Pumpe ungenau ist. Diese Aktion sollte NIE durchgeführt werden wenn die Pumpe im Loop verwendet wird. Wenn Sie diese Aktion trotzdem durchführen möchten, drücken Sie lange erneut auf den diesen Knopf.\nWARNUNG: Es gibt einen bekannten Fehler in der Pumpe der dazu führt, dass die Pumpe nach dieser Aktion erst wieder Verbindungen annimmt, wenn auf der Pumpe selbst ein Konpf gedrückt wird. Aus diesem Grund sollte diese Aktion nicht durchgeführt werden.</string>
+    <string name="combo_read_full_history_warning">Diese Aktion wird die gesamte Historie und die Basalrate aus der Pumpe auslesen. Boli und temporäre Basalrate werden zu den Behandlungen hinzugefügt wenn diese noch nicht vorhanden sind. Dies kann zu doppelten Einträge und somit zu falschen IOB-Werten führen, da die Uhr der Pumpe ungenau ist. Diese Aktion sollte NIE durchgeführt werden wenn die Pumpe im Loop verwendet wird. Wenn Sie diese Aktion trotzdem durchführen möchten, drücken Sie lange erneut auf den diesen Knopf.\nWARNUNG: Es gibt einen bekannten Fehler in der Pumpe der dazu führt, dass die Pumpe nach dieser Aktion erst wieder Verbindungen annimmt, wenn auf der Pumpe selbst ein Konpf gedrückt wird. Aus diesem Grund sollte diese Aktion nicht durchgeführt werden.</string>
 </resources>


### PR DESCRIPTION
In this branch this 4 lines are not used, but indeed in Milos dev branch. This lines make it impossible to compile the app.
Other changes:
Historik -> Historie ("Historik" meint "Geschichtswissenschaft" bzw. die "Lehre von der historischen Methode der Geschichtswissenschaft". "Historie" meint das zwar auch, ist aber insgesamt ein wenig weiter gefasst und meint (bildungssprachlich) auch allgemein die Geschichte, nicht nur die Wissenschaft)
OBJ -> ZIEL (Anpassung der Kurzüberschrift an dt. Übersetzung)