### PR TITLE
Don't send carbs from the past to the pump

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/CarbsGenerator.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/CarbsGenerator.java
@@ -44,7 +44,7 @@ public class CarbsGenerator {
         carbInfo.context = MainApp.instance();
         carbInfo.source = Source.USER;
         carbInfo.notes = notes;
-        if (ConfigBuilderPlugin.getActivePump().getPumpDescription().storesCarbInfo && carbInfo.date <= now()) {
+        if (ConfigBuilderPlugin.getActivePump().getPumpDescription().storesCarbInfo && (Math.abs(carbInfo.date - now()) < T.mins(1).msecs())) {
             ConfigBuilderPlugin.getCommandQueue().bolus(carbInfo, new Callback() {
                 @Override
                 public void run() {


### PR DESCRIPTION
The pumps that store carbs do not support times other than "now".
If you decide to add carbs that you forgot to enter, they will be added at a wrong time if going through pump history -> directly store them.